### PR TITLE
add: フォーマッターを追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Django>=4.2,<5.0
 psycopg2-binary>=2.9,<3.0
 djangorestframework==3.15.2
 django-cors-headers
+black


### PR DESCRIPTION
## 実施事項
Pritter、blackを使用してフォーマッターが使えるようにしました。

## 動作確認
下記の手順でblackが使用できます。

- 仮想環境のアクティベート:
`source venv/bin/activate`  # Linuxの場合
`venv\Scripts\activate`　　 # Windowsの場合
 - requirements.txt に基づいて依存関係のインストール:
`pip install -r requirements.txt`  
- コマンドをたたくと成形
`black .`

![image](https://github.com/user-attachments/assets/98f514f2-0667-456a-9716-ba8ac27ab4e4)

Black Formatterをインストールすると保存するたび成形が可能になります。
![image](https://github.com/user-attachments/assets/538238a5-64c2-4bdf-8222-9cb95390f81b)


## その他
